### PR TITLE
docs: Update Hello world.mdx

### DIFF
--- a/docs/Hello world.mdx
+++ b/docs/Hello world.mdx
@@ -277,7 +277,7 @@ Finally, we will use IFC.js to load IFC files. This can be done by instantiating
       var ifcURL = URL.createObjectURL(file);
       ifcLoader.load(
             ifcURL,
-            (ifcModel) => scene.add(ifcModel.mesh));
+            (ifcModel) => scene.add(ifcModel));
     },
     false
   );
@@ -309,7 +309,7 @@ In the first case, it is sufficient to reference the URL of the IFC file. That i
 ```js
 ifcLoader.load(
     "models/Example_model.ifc",
-    (ifcModel) => scene.add(ifcModel.mesh));
+    (ifcModel) => scene.add(ifcModel));
 ```
 
 <IfcAlert>

--- a/docs/Hello world.mdx
+++ b/docs/Hello world.mdx
@@ -144,7 +144,7 @@ Also, the `package.json` file needs to be modified to contain the commands to co
   },
   "dependencies": {
     "three": "^0.128.0",
-    "web-ifc-three": "0.0.32"
+    "web-ifc-three": "0.0.102"
   }
 }
 ```


### PR DESCRIPTION
Latest version of web-ifc-three (0.0.102) has deprecated the `mesh` property of `IFCModel`:
```
@deprecated — IfcModel is already a mesh; you can place it in the scene directly.

'mesh' is deprecated.ts(6385)
IFCModel.d.ts(14, 8): The declaration was marked as deprecated here.
```