### PR TITLE
docs: Update Picking.mdx

### DIFF
--- a/docs/Guide/web-ifc-three/Tutorials/Picking.mdx
+++ b/docs/Guide/web-ifc-three/Tutorials/Picking.mdx
@@ -59,8 +59,8 @@ const ifcLoader = new IFCLoader();
 async function loadIFC() {
     await ifcLoader.ifcManager.setWasmPath("../../");
     ifcLoader.load("../../IFC/01.ifc", (ifcModel) => {
-        ifcModels.push(ifcModel.mesh);
-        scene.add(ifcModel.mesh);
+        ifcModels.push(ifcModel);
+        scene.add(ifcModel);
     });
 }
 


### PR DESCRIPTION
`ifcModel` is a class that extend `THREE.mesh` -- the `mesh` property is deprecated.